### PR TITLE
Display purchase hint on buy listing cards

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -255,7 +255,12 @@ function ListingCard({ listing, onDelete }) {
           <Badge color={isSell ? "bg-emerald-100 text-emerald-800" : "bg-sky-100 text-sky-800"}>{isSell ? "SPRZEDAM" : "KUPIĘ"}</Badge>
           <h3 className="font-semibold text-lg">{listing.raceName}</h3>
         </div>
-        <div className="text-right font-semibold">{toPLN(listing.price)}</div>
+        <div className="text-right">
+          {!isSell && (
+            <div className="text-xs text-gray-500 leading-tight">Proponowana cena zakupu</div>
+          )}
+          <div className="font-semibold">{toPLN(listing.price)}</div>
+        </div>
       </div>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-sm text-gray-600 mb-2">
         <div>


### PR DESCRIPTION
## Summary
- wrap the listing price section in a right-aligned container
- show a "Proponowana cena zakupu" hint above prices for buy listings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb34fcc71883229802f0c9d640b68f