### PR TITLE
Fix scraper slug collisions by city

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ Skrypt wysyła żądania co ok. 800 ms z nagłówkiem `User-Agent: RaceMarketpla
 wykonuje idempotentne upserty – wielokrotne uruchomienie nie duplikuje danych. W logach znajdziesz liczbę przetworzonych
 stron, wpisów oraz statystyki upsertów.
 
+### Scraper – kolizje slugów
+
+- Podczas wyszukiwania wydarzenia scraper porównuje nazwę i miasto case-insensitive, więc ponowne uruchomienie nie duplikuje
+  rekordów.
+- Slugi są budowane z nazwy oraz miasta (np. `bieg-niepodleglosci-warszawa`). Jeśli slug jest zajęty, kolejne próby dodają
+  sufiks `-2`, `-3`, ... – informacja o kolizji pojawia się w logu (`[scraper] slug collision for ...`).
+- Wstawianie rekordu ponawia się w razie konfliktu klucza unikalnego, by zachować idempotentność nawet przy równoległym
+  uruchomieniu.
+
 ### Integracja z Vercel Cron (opcjonalnie)
 
 Repozytorium zawiera plik `vercel.json` oraz endpoint `api/run-scraper.js`. Po wdrożeniu na Vercel cron raz w tygodniu


### PR DESCRIPTION
## Summary
- make the marathon scraper reuse existing events by matching name and city case-insensitively
- generate unique slugs based on name and city with collision logging and retry on unique constraint errors
- document slug collision behaviour in the README

## Testing
- npm run build

## Preview
- not available in the local test environment

## Logs
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd70141d7c832288585a1b21c25b99