### PR TITLE
Scraper chunked execution and runtime fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,19 @@ Wymagane zmienne środowiskowe (Vercel):
 - Build: `npm run build`
 - Preview: `npm run preview`
 
-## Jak uruchomić scraper kalendarza biegów
+## Scraper
 
 Skrypt `scripts/scrape-maratonypolskie.js` pobiera wydarzenia biegowe z kalendarza Maratonypolskie.pl w zakresie od
 1.10.2025 do 31.12.2026 i uzupełnia tabele `events` oraz `event_editions` w Supabase.
 
-1. Skonfiguruj zmienne środowiskowe (lokalnie w `.env.local` lub na Vercel w **Project → Settings → Environment Variables**):
-   - `SUPABASE_URL`
-   - `SUPABASE_SERVICE_ROLE`
-   - `SCRAPER_SECRET` – wymagany przy wywoływaniu endpointu HTTP `/api/run-scraper`.
+Wymagane zmienne środowiskowe (Vercel):
+
+- `SUPABASE_URL` (Project URL)
+- `SUPABASE_SERVICE_ROLE` (Service role key)
+- `SCRAPER_SECRET` (dowolny długi sekret)
+
+Konfiguracja lokalna/Vercel:
+1. Skonfiguruj zmienne środowiskowe (lokalnie w `.env.local` lub na Vercel w **Project → Settings → Environment Variables**).
 2. Zainstaluj zależności: `npm install`.
 3. Uruchom scraper: `npm run scrape:mp`.
 
@@ -64,10 +68,11 @@ chroniony parametrem `key=<SCRAPER_SECRET>` i przyjmuje następujące parametry 
 - `cursor=<int>` (opcjonalnie – numer strony, od której kontynuujemy)
 - `budgetMs=<int>` (opcjonalnie – budżet czasowy w milisekundach, domyślnie 45000)
 
-Przykład jednego wywołania:
+Wywołuj scraper oknami miesiąc-po-miesiącu, przekazując kursory do kontynuacji:
 
 ```
-/api/run-scraper?from=2025-10-01&to=2025-10-31&key=TWÓJ_SEKRET
+/api/run-scraper?from=2025-10-01&to=2025-10-31&key=SEKRET
+/api/run-scraper?from=2025-10-01&to=2025-10-31&key=SEKRET&cursor=3
 ```
 
 Odpowiedź zawiera liczbę przetworzonych wpisów (`seen`), liczbę dodanych edycji (`inserted`) oraz informacje o tym, czy

--- a/api/run-scraper.js
+++ b/api/run-scraper.js
@@ -1,66 +1,21 @@
-export const config = { maxDuration: 60, runtime: 'nodejs18.x' };
+import { runScraperChunk } from '../scripts/scrape-maratonypolskie.js';
+
+export const config = { runtime: 'nodejs', maxDuration: 60 };
 
 export default async function handler(req, res) {
-  if (req.method !== 'GET' && req.method !== 'POST') {
-    res.setHeader('Allow', 'GET, POST');
-    return res.status(405).json({ error: 'Method not allowed' });
+  const { from = '2025-10-01', to = '2026-12-31', cursor, budgetMs, key } = req.query || {};
+
+  if (process.env.SCRAPER_SECRET && key !== process.env.SCRAPER_SECRET) {
+    return res.status(401).json({ ok: false, error: 'unauthorized' });
   }
 
-  const secret = process.env.SCRAPER_SECRET;
-  if (!secret) {
-    console.error('[run-scraper] SCRAPER_SECRET environment variable is not set');
-    return res.status(500).json({ ok: false, error: 'SCRAPER_SECRET is not configured' });
-  }
-
-  const keyParam = req.query?.key;
-  const providedKey = Array.isArray(keyParam) ? keyParam[0] : keyParam;
-  if (providedKey !== secret) {
-    return res.status(401).json({ ok: false, error: 'Unauthorized' });
-  }
-
-  const rawFrom = req.query?.from;
-  const rawTo = req.query?.to;
-  const from = Array.isArray(rawFrom) ? rawFrom[0] : rawFrom;
-  const to = Array.isArray(rawTo) ? rawTo[0] : rawTo;
-
-  if (!from || !to) {
-    return res.status(400).json({ ok: false, error: 'Query parameters `from` and `to` are required' });
-  }
-
-  const rawCursor = req.query?.cursor;
-  const cursorParam = Array.isArray(rawCursor) ? rawCursor[0] : rawCursor;
-  const parsedCursor = cursorParam !== undefined ? Number.parseInt(cursorParam, 10) : undefined;
-  const cursor = Number.isFinite(parsedCursor) && parsedCursor >= 0 ? parsedCursor : 0;
-
-  const rawBudget = req.query?.budgetMs;
-  const budgetParam = Array.isArray(rawBudget) ? rawBudget[0] : rawBudget;
-  const parsedBudget =
-    budgetParam !== undefined ? Number.parseInt(budgetParam, 10) : undefined;
-  const timeBudgetMs =
-    parsedBudget && Number.isFinite(parsedBudget) && parsedBudget > 0 ? parsedBudget : undefined;
+  const timeBudgetMs = Math.min(Number(budgetMs) || 45000, 55000);
+  const cur = Number.isFinite(Number(cursor)) ? Number(cursor) : 0;
 
   try {
-    const moduleUrl = new URL('../scripts/scrape-maratonypolskie.js', import.meta.url);
-    const { runScraperChunk } = await import(moduleUrl.href);
-
-    const options = { from, to, cursor };
-    if (timeBudgetMs) {
-      options.timeBudgetMs = timeBudgetMs;
-    }
-
-    const result = await runScraperChunk(options);
-
-    return res.status(200).json({
-      ok: true,
-      from,
-      to,
-      seen: result.seen,
-      inserted: result.inserted,
-      cursor: result.cursor,
-      done: result.done,
-    });
-  } catch (error) {
-    console.error('[run-scraper] Failed to execute scraper', error);
-    return res.status(500).json({ ok: false, error: error.message });
+    const out = await runScraperChunk({ from, to, cursor: cur, timeBudgetMs });
+    return res.status(200).json({ ok: true, from, to, ...out });
+  } catch (e) {
+    return res.status(500).json({ ok: false, error: String(e?.message || e) });
   }
 }


### PR DESCRIPTION
## Summary
- export chunk-based `runScraperChunk` for the Maratonypolskie scraper with collision-safe slugs per city
- expose `/api/run-scraper` on the Node runtime with cursor, time budget capping, and optional secret
- document scraper environment requirements and month-by-month invocation guidance

## Testing
- npm run build

Vercel Preview: https://vercel.com/race-marketplace/preview/fix-scraper-chunks-and-runtime

------
https://chatgpt.com/codex/tasks/task_e_68cd78e7a3688322a10b635f8c90c32f