### PR TITLE
Display name at signup and private messages MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Stack: Vite + React + TailwindCSS. Dane są w localStorage przeglądarki.
 1. W Supabase uruchom kolejno migracje z katalogu `supabase/migrations` (jeśli jeszcze nie były stosowane).
 2. Następnie uruchom skrypt `supabase/alerts.sql` w edytorze SQL, aby dodać tabele `listings`, `alerts`, `notifications`, widok
    `alerts_match` oraz kolumnę `email_notifications` w tabeli `profiles`.
+3. Uruchom skrypt `supabase/messages.sql`, który dodaje tabelę profili (jeśli nie istnieje), tabelę `messages` oraz polityki RLS
+   wymagane do obsługi prywatnych wiadomości i aktualizacji pola `display_name`.
 
 Wymagane zmienne środowiskowe (Vercel):
 

--- a/supabase/messages.sql
+++ b/supabase/messages.sql
@@ -1,0 +1,38 @@
+-- profiles (jeśli nie istnieje)
+create table if not exists public.profiles(
+  id uuid primary key references auth.users(id) on delete cascade,
+  display_name text not null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- messages (proste 1:1, bez wątków)
+create table if not exists public.messages(
+  id bigserial primary key,
+  from_user uuid not null references public.profiles(id) on delete cascade,
+  to_user uuid not null references public.profiles(id) on delete cascade,
+  listing_id text,
+  body text not null check (length(body) <= 4000),
+  created_at timestamptz default now(),
+  read_at timestamptz
+);
+
+-- RLS
+alter table public.profiles enable row level security;
+alter table public.messages enable row level security;
+
+-- Profile: każdy czyta tylko siebie, zapis: tylko właściciel
+create policy "profiles_select_own" on public.profiles
+for select using (auth.uid() = id);
+create policy "profiles_upsert_own" on public.profiles
+for insert with check (auth.uid() = id);
+create policy "profiles_update_own" on public.profiles
+for update using (auth.uid() = id);
+
+-- Messages: nadawca lub odbiorca może czytać; wysyła tylko zalogowany jako from_user; read_at ustawia tylko odbiorca
+create policy "messages_select_participant" on public.messages
+for select using (auth.uid() = from_user or auth.uid() = to_user);
+create policy "messages_insert_self_sender" on public.messages
+for insert with check (auth.uid() = from_user);
+create policy "messages_update_mark_read" on public.messages
+for update using (auth.uid() = to_user);


### PR DESCRIPTION
## Summary
- require a display name during registration, store it in profiles, and fetch it into the session
- surface author display names on listing cards/detail modal with fallbacks for the listing owner
- add Supabase SQL for the new `messages` table/RLS, plus a messaging modal, inbox view with unread counter, and real-time badge updates

## Testing
- npm run build

## Notes
- Vercel Preview: (local run only in this environment)
- Run the new schema with `supabase/messages.sql` after the existing migrations to create the `messages` table and related policies.

------
https://chatgpt.com/codex/tasks/task_e_68cdba53f5c483228fcbc5102b966121