### PR TITLE
Remove legacy ownership filter effect

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2842,7 +2842,6 @@ export default function App() {
 
   useEffect(() => {
     if (!currentUserId) {
-      setOwnershipFilter("all");
       setEditingListing(null);
     }
   }, [currentUserId]);


### PR DESCRIPTION
## Summary
- remove the logout useEffect reference to the removed ownership filter while keeping the edit reset

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68cdeb85b41c832283a9d636eafa1143