### PR TITLE
Define author label for ListingCard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1838,6 +1838,8 @@ function ListingCard({ listing, onDelete, onOpen, onMessage, currentUserId, onEd
       listingProofCheckedLabel = parsed.toLocaleString("pl-PL");
     }
   }
+  const authorLabel =
+    listing.author_display_name || (ownerId && ownerId === currentUserId ? viewerDisplayName : "");
   return (
     <div
       id={listing.id}


### PR DESCRIPTION
## Summary
- derive `authorLabel` inside `ListingCard` using the same fallback logic as `DetailModal`

## Testing
- npm run dev -- --host

------
https://chatgpt.com/codex/tasks/task_e_68cf1c447a008322acc7fef80bfe5864