### PR TITLE
Handle localStorage failures when saving listings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -154,7 +154,14 @@ function loadListings() {
 
 /** @param {Listing[]} listings */
 function saveListings(listings) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(listings));
+  try {
+    const serialized = JSON.stringify(listings);
+    localStorage.setItem(STORAGE_KEY, serialized);
+    return true;
+  } catch (err) {
+    console.error("Nie udało się zapisać ogłoszeń w localStorage", err);
+    return false;
+  }
 }
 
 function toCurrency(v, currency = "PLN") {
@@ -2763,8 +2770,18 @@ export default function App() {
   }, [purgeExpiredListings]);
 
   useEffect(() => {
-    saveListings(listings);
-  }, [listings]);
+    const errorMessage = "Nie udało się zapisać ogłoszeń w pamięci przeglądarki.";
+    try {
+      const success = saveListings(listings);
+      if (!success) {
+        console.error(errorMessage);
+        showToast(errorMessage);
+      }
+    } catch (err) {
+      console.error(errorMessage, err);
+      showToast(errorMessage);
+    }
+  }, [listings, showToast]);
 
   useEffect(() => {
     const interval = setInterval(() => {


### PR DESCRIPTION
## Summary
- wrap the listings persistence helper in a try/catch so localStorage errors are logged and reported
- handle failed saves in the listings persistence effect by showing a toast instead of letting the exception crash the UI

## Testing
- npm run build
- manual verification by starting the dev server with dummy Supabase env values and patching localStorage.setItem to throw via Playwright to ensure the toast appears and the page stays rendered


------
https://chatgpt.com/codex/tasks/task_e_68cf1d960c4083228573ec738df79d7d